### PR TITLE
BugFix: invalid txCount hex when submit block (#11)

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -74,18 +74,19 @@ var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, extr
 
     // join the header and txs together
     this.serializeBlock = function(header, soln){
+
+        var txCount = this.txCount.toString(16);
+        if (Math.abs(txCount.length % 2) == 1) {
+          txCount = "0" + txCount;
+        }
+        
         if (this.txCount <= 0x7f){
-            if (this.txCount <= 0x7f) {
-                var txCount = '0' + this.txCount;
-            }
             var varInt = new Buffer(txCount, 'hex');
         }
         else if (this.txCount <= 0x7fff){
-            if (this.txCount <= 0x7ff) {
-                var txCount = '0' + this.txCount;
-            }
             var varInt = new Buffer.concat([Buffer('FD', 'hex'), new Buffer(txCount, 'hex')]);
         }
+        
         buf = new Buffer.concat([
             header,
             soln,


### PR DESCRIPTION
Invalid hex was being generated when the tx count exceeded 16.