### PR TITLE
Authorize / Pool Fee Changes (#14)

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -270,7 +270,7 @@ var pool = module.exports = function pool(options, authorizeFn) {
         for (var r in options.rewardRecipients) {
             var percent = options.rewardRecipients[r];
             var rObj = {
-                percent: (percent / 100),
+                percent: percent,
                 address: r
             };
                 recipients.push(rObj);

--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -121,28 +121,41 @@ var StratumClient = function(options){
     }
 
     function handleAuthorize(message){
-        _this.workerName = message.params[0];
+        _this.workerName = message.params[0].split('.')[0];
         _this.workerPass = message.params[1];
 
-        options.authorizeFn(_this.remoteAddress, options.socket.localPort, _this.workerName, _this.workerPass, function(result) {
-            _this.authorized = (!result.error && result.authorized);
+        // simple only allow t-addr
+        if (!_this.workerName.startsWith('t')) {
 
-            sendJson({
-                id     : message.id,
-                result : _this.authorized,
-                error  : result.error
-            });
+	    _this.authorized = false;
 
-            // If the authorizer wants us to close the socket lets do it.
-            if (result.disconnect === true) {
-                options.socket.destroy();
-            }
-        });
+	    sendJson({
+	        id     : message.id,
+	        result : _this.authorized,
+	        error  : "invalid address"
+	    });
+
+        } else {
+
+	  options.authorizeFn(_this.remoteAddress, options.socket.localPort, _this.workerName, _this.workerPass, function(result) {
+	    _this.authorized = (!result.error && result.authorized);
+
+	    sendJson({
+		id     : message.id,
+		result : _this.authorized,
+		error  : result.error
+	    });
+
+	    // If the authorizer wants us to close the socket lets do it.
+	    if (result.disconnect === true) {
+		options.socket.destroy();
+	    }
+	  });
+
+        }
     }
 
     function handleSubmit(message){
-        // disable authentication for now due to Claymore miner submitting unauthenticated 'tax' work
-        /*
         if (_this.authorized === false){
             sendJson({
                 id    : message.id,
@@ -152,7 +165,6 @@ var StratumClient = function(options){
             considerBan(false);
             return;
         }
-        */
         if (!_this.extraNonce1){
             sendJson({
                 id    : message.id,

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -74,7 +74,7 @@ exports.createGeneration = function(blockHeight, blockReward, feeReward, recipie
         // pool
         tx.addOutput(
             scriptCompile(poolAddrHash),
-            Math.round(blockReward * (1 - (percentFoundersReward + feePercent) / 100)) + Math.round(feeReward * (1 - (feePercent / 100)))
+            Math.round(blockReward * (1 - (percentFoundersReward + feePercent) / 100)) + feeReward
         );
         // founders
         tx.addOutput(
@@ -85,7 +85,7 @@ exports.createGeneration = function(blockHeight, blockReward, feeReward, recipie
         for (var i = 0; i < recipients.length; i++) {
            tx.addOutput(
                scriptCompile(bitcoin.address.fromBase58Check(recipients[i].address).hash),
-               Math.round(blockReward  * (recipients[i].percent / 100)) + Math.round(feeReward * (recipients[i].percent / 100))
+               Math.round(blockReward  * (recipients[i].percent / 100))
            );
         }
     }
@@ -94,13 +94,13 @@ exports.createGeneration = function(blockHeight, blockReward, feeReward, recipie
         // pool
         tx.addOutput(
             scriptCompile(poolAddrHash),
-            Math.round(blockReward * (1 - (feePercent / 100))) + Math.round(feeReward * (1 - (feePercent / 100)))
+            Math.round(blockReward * (1 - (feePercent / 100))) + feeReward
         );
         // recipients
         for (var i = 0; i < recipients.length; i++) {
            tx.addOutput(
                scriptCompile(bitcoin.address.fromBase58Check(recipients[i].address).hash),
-               Math.round(blockReward * (recipients[i].percent / 100)) + Math.round(feeReward * (recipients[i].percent / 100))
+               Math.round(blockReward * (recipients[i].percent / 100))
            );
         }    
     }


### PR DESCRIPTION
* Pool fees being calculated incorrectly.

* Pool fee recipients do not earn fee rewards

* Support worker names

Remove worker name from address.
Accept only t-addr, z-addr unsupported at this time.
Enable authorize function to prevent invalid address from earning shares breaking payouts.
(ClaymoreZCash works just fine with -allpools 1)